### PR TITLE
docs: apply various changes

### DIFF
--- a/exception-handler.md
+++ b/exception-handler.md
@@ -116,7 +116,7 @@ public function report(Throwable $exception)
 }
 ```
 
-If you would like to disable the reporting only when running from the built phar file you could use the [`\Phar::running()`](http://php.net/manual/en/phar.running.php) function.
+If you would like to disable the reporting only when running from the built phar file you could use the [`\Phar::running()`](https://php.net/manual/en/phar.running.php) function.
 
 ```php
 if (\Phar::running()) {

--- a/filesystem.md
+++ b/filesystem.md
@@ -5,7 +5,7 @@ description: Filesystem interaction through Storage of File facade, just like La
 
 # Filesystem
 
-If you want to move files in your system, or to different providers like AwsS3 and Dropbox. By default,
+If you want to move files in your system, or to different providers like AWS S3 and Dropbox. By default,
 Laravel Zero ships with the [Filesystem](https://laravel.com/docs/filesystem) component of Laravel.
 
 **Note:** By default the root directory is `your-app-name/storage`.
@@ -67,5 +67,5 @@ return [
 Using the `File` facade is just the same as normal
 
 ```php 
-File::put( getcwd() . DIRECTORY_SEPARATOR . "reminders.txt", "Task 1");
+File::put(getcwd() . "/reminders.txt", "Task 1");
 ```

--- a/installation.md
+++ b/installation.md
@@ -9,27 +9,10 @@ description: Create a new Laravel Zero project
 
 Laravel Zero utilizes [Composer](https://getcomposer.org) to manage its dependencies. So, before using Laravel Zero, make sure you have Composer installed on your machine.
 
-<a name="via-the-laravel-zero-installer"></a>
-#### Via the Laravel Zero Installer
-
-First, download the Laravel Zero installer using Composer:
-
-```bash
-composer global require "laravel-zero/installer"
-```
-
-Make sure to place composer's system-wide vendor bin directory in your `$PATH` so the laravel Zero executable can be located by your system. This directory exists in different locations based on your operating system. On macOS and GNU/Linux distributions, it's `$HOME/.composer/vendor/bin`.
-
-Once installed, the `laravel-zero new` command will create a fresh Laravel Zero installation in the directory you specify. For instance, `laravel-zero new movie-cli` will create a directory named `movie-cli` containing a fresh Laravel Zero installation with all of Laravel Zero's dependencies already installed:
-
-```bash
-laravel-zero new movie-cli
-```
-
 <a name="via-composer-create-project"></a>
 #### Via Composer Create-Project
 
-Alternatively, you may also install Laravel Zero by issuing the Composer `create-project` command in your terminal:
+You may install Laravel Zero by issuing the Composer `create-project` command in your terminal:
 
 ```bash
 composer create-project --prefer-dist laravel-zero/laravel-zero movie-cli
@@ -40,3 +23,24 @@ You will then need to run the `app:rename` command to rename your project:
 ```bash
 php application app:rename [movie-cli]
 ```
+
+<a name="via-the-laravel-zero-installer"></a>
+#### Via the Laravel Zero Installer (DEPRECATED)
+
+> Note: This method is deprecated, although it will continue to work.
+
+If you would like to use the Laravel Zero installer, install it using Composer:
+
+```bash
+composer global require "laravel-zero/installer"
+```
+
+Make sure to place composer's system-wide vendor bin directory in your `$PATH` so the Laravel Zero executable can be located by your system. This directory exists in different locations based on your operating system. On macOS and GNU/Linux distributions, it's `$HOME/.composer/vendor/bin`.
+
+Once installed, the `laravel-zero new` command will create a fresh Laravel Zero installation in the directory you specify. For instance, `laravel-zero new movie-cli` will create a directory named `movie-cli` containing a fresh Laravel Zero installation with all of Laravel Zero's dependencies already installed:
+
+```bash
+laravel-zero new movie-cli
+```
+
+On versions v2.5.0 and later, the command will also automatically rename your app.

--- a/web-browser-automation.md
+++ b/web-browser-automation.md
@@ -23,7 +23,7 @@ class VisitLaravelZeroCommand extends Command
     public function handle()
     {
         $this->browse(function ($browser) {
-            $browser->visit('http://laravel-zero.com')
+            $browser->visit('https://laravel-zero.com')
                 ->assertSee('Collision');
         });
     }


### PR DESCRIPTION
- Updates some wording on the filesystem page (`AwsS3 => AWS S3` and using `/` instead of `DIRECTORY_SEPARATOR`)
- Updates a few uses of HTTP to HTTPS (leaving Figlet, as that is HTTP-only)
- Updates the order of the Laravel Zero installer and marks it as deprecated