### PR TITLE
Change 'App\ServiceProviders' to 'app/Providers'

### DIFF
--- a/service-providers.md
+++ b/service-providers.md
@@ -1,11 +1,11 @@
 ---
 title: Service Providers
-description: The `App\ServiceProviders` folder
+description: The `app/Providers` folder
 ---
 
 # Service Providers
 
-The `App\ServiceProviders` folder should contain Service Providers files. The usage of
+The `app/Providers` folder should contain Service Providers files. The usage of
 [Laravel Service Providers](https://laravel.com/docs/providers) is the best way to specify
 when a concrete implementation is bound to a contract/interface:
 ```php


### PR DESCRIPTION
The namespace is `App\Providers` rather than `App\ServiceProviders`.

Also the sentence says "The folder" not "The namespace", so I changed `App\` to `app/` (consistent with the filenames in the Configuration page - although it's not consistent with the Commands page which uses backslashes in the filename, so not sure which you prefer).