### PR TITLE
docs: add anchor to debug-information

### DIFF
--- a/build-a-standalone-application.md
+++ b/build-a-standalone-application.md
@@ -24,6 +24,7 @@ We use [`humbug/box`](https://github.com/box-project/box) to provide fast applic
 
 Please check the box documentation to understand all options: [github.com/box-project/box/blob/master/doc/configuration.md](https://github.com/box-project/box/blob/master/doc/configuration.md).
 
+<a name="debug-information"></a>
 ### Debug information
 
 #### Failing build?


### PR DESCRIPTION
I missed the link anchor.